### PR TITLE
캘린더 상세 스타일링 & 일정 개수 반환 API 적용

### DIFF
--- a/src/apis/schedule/scheduleCount.js
+++ b/src/apis/schedule/scheduleCount.js
@@ -1,0 +1,19 @@
+import axios from 'axios';
+
+const apiUrl = process.env.REACT_APP_API_URL;
+const authToken = process.env.REACT_APP_API_AUTH_TOKEN;
+
+const fetchScheduleCounts = (date) => {
+  const endPoint = '/calendar/schedules/month';
+  const url = `${apiUrl}${endPoint}`;
+
+  return axios.get(url, {
+    params: { date },
+    headers: {
+      Accept: '*/*',
+      Authorization: authToken,
+    },
+  });
+};
+
+export { fetchScheduleCounts };

--- a/src/components/calendar/MySchedule.js
+++ b/src/components/calendar/MySchedule.js
@@ -27,7 +27,7 @@ import img_schedule from 'assets/images/schedule_img.svg';
 import { getSchedules } from 'apis/schedule/scheduleGet';
 import { deleteSchedule } from 'apis/schedule/scheduleDelete';
 
-const MySchedule = ({ selectedDate }) => {
+const MySchedule = ({ selectedDate, updateScheduleDates }) => {
   const { isModalOpen, openModal, closeModal } = MyScheduleHook();
   const [schedules, setSchedules] = useState([]);
 
@@ -55,12 +55,14 @@ const MySchedule = ({ selectedDate }) => {
 
   // 일정 삭제 핸들러
   const handleDelete = (scheduleId) => {
+    const isoDate = moment(selectedDate, 'YYYY년 M월 D일').format('YYYY-MM-DD');
     deleteSchedule(scheduleId)
       .then(() => {
         // 성공적으로 삭제된 경우, 스케줄 목록 업데이트
         setSchedules(
           schedules.filter((schedule) => schedule.id !== scheduleId)
         );
+        updateScheduleDates(isoDate, -1); // 일정 개수 업데이트
       })
       .catch((error) => {
         console.error('Error deleting schedule:', error);
@@ -104,6 +106,7 @@ const MySchedule = ({ selectedDate }) => {
           onClose={closeModal}
           selectedDate={selectedDate}
           onAddSchedule={handleAddSchedule}
+          updateScheduleDates={updateScheduleDates}
         />
       )}
     </ScheduleBox>

--- a/src/components/calendar/SchedulePopUp.js
+++ b/src/components/calendar/SchedulePopUp.js
@@ -22,6 +22,7 @@ const SchedulePopUp = ({
   onClose,
   selectedDate,
   onAddSchedule,
+  updateScheduleDates,
 }) => {
   // 모달이 열려있지 않으면 null 반환
   if (!isOpen) return null;
@@ -37,6 +38,7 @@ const SchedulePopUp = ({
         onClose={onClose}
         selectedDate={selectedDate}
         onAddSchedule={onAddSchedule}
+        updateScheduleDates={updateScheduleDates}
       />
     </Modal>
   );

--- a/src/components/calendar/SchedulePopUpContent.js
+++ b/src/components/calendar/SchedulePopUpContent.js
@@ -10,7 +10,12 @@ import {
 import SchedulePopUpContentHook from 'hooks/calendar/SchedulePopUpContentHook';
 import { postSchedule } from 'apis/schedule/schedulePost';
 
-const SchedulePopUpContent = ({ onClose, selectedDate, onAddSchedule }) => {
+const SchedulePopUpContent = ({
+  onClose,
+  selectedDate,
+  onAddSchedule,
+  updateScheduleDates,
+}) => {
   const { title, content, handleTitleChange, handleContentChange } =
     SchedulePopUpContentHook(onClose);
 
@@ -32,6 +37,7 @@ const SchedulePopUpContent = ({ onClose, selectedDate, onAddSchedule }) => {
       .then((response) => {
         console.log('Data posted successfully:', response.data);
         onAddSchedule(response.data);
+        updateScheduleDates(date, 1);
       })
       .catch((error) => {
         console.error('Error posting data:', error);

--- a/src/pages/MyFullCalendar.js
+++ b/src/pages/MyFullCalendar.js
@@ -9,12 +9,14 @@ import Mission from 'components/calendar/Mission';
 import img_calendarToggleDownBtn from 'assets/images/calendar_toggle_down_btn.png';
 import img_calendarToggleUpBtn from 'assets/images/calendar_toggle_up_btn.png';
 import img_calendarPopUpBtn from 'assets/images/calendar_popup_btn.png';
-
+import { useEffect, useState } from 'react';
+import moment from 'moment';
 import {
   CalendarWrapper,
   CalendarToggleButton,
 } from 'styles/calendar/Calendar-styled';
 import { MyFullCalendarHook } from 'hooks/calendar/MyFullCalendarHook';
+import { fetchScheduleCounts } from 'apis/schedule/scheduleCount';
 
 const MyFullCalendar = () => {
   const {
@@ -28,9 +30,76 @@ const MyFullCalendar = () => {
     toggleView,
   } = MyFullCalendarHook();
 
-  // Calendar의 date에서 일 제거
+  const [scheduleDates, setScheduleDates] = useState([]);
+
+  useEffect(() => {
+    // 일정 개수 조회 포맷 YYYY-MM-DD
+    const isoDate = moment(selectedDate, 'YYYY년 M월 D일').format('YYYY-MM-DD');
+
+    // API 호출을 통해 일정 개수 가져오기
+    fetchScheduleCounts(isoDate)
+      .then((response) => {
+        console.log('Schedules for the selected month:', response.data);
+        // 날짜별 일정 개수를 객체 형태로 변환
+        const datesWithSchedules = response.data.reduce((acc, entry) => {
+          acc[entry.date] = entry.count;
+          return acc;
+        }, {});
+        console.log('DateWithSchedules:', datesWithSchedules);
+        setScheduleDates(datesWithSchedules);
+      })
+      .catch((error) => {
+        console.error('Error fetching schedules:', error);
+      });
+
+    // selectedDate 바뀔 때마다 재렌더링
+  }, [selectedDate]);
+
+  // 일정 날짜 업데이트 함수
+  const updateScheduleDates = (date, countChange) => {
+    setScheduleDates((prev) => {
+      const newScheduleDates = { ...prev };
+      newScheduleDates[date] = (newScheduleDates[date] || 0) + countChange;
+      if (newScheduleDates[date] <= 0) delete newScheduleDates[date];
+      return newScheduleDates;
+    });
+  };
+
+  // Full Calendar의 dayCellContent에 일정 개수 표시
   const dayCellContent = (arg) => {
-    return arg.date.getDate().toString();
+    const cellDate = moment(arg.date).format('YYYY-MM-DD');
+    const scheduleCount = scheduleDates[cellDate] || 0;
+    const dotCount = Math.min(scheduleCount, 2); // 최대 2개의 점만 표시
+
+    return (
+      <div style={{ position: 'relative' }}>
+        {arg.date.getDate()}
+        {dotCount > 0 && (
+          <div
+            style={{
+              position: 'absolute',
+              top: '34px',
+              width: '100%',
+              display: 'flex',
+              justifyContent: 'center',
+            }}
+          >
+            {Array.from({ length: dotCount }).map((_, index) => (
+              <div
+                key={index}
+                style={{
+                  width: '9px',
+                  height: '9px',
+                  backgroundColor: '#5643D1',
+                  borderRadius: '50%',
+                  marginLeft: index === 0 ? '0' : '5px', // 점 간격 조정
+                }}
+              />
+            ))}
+          </div>
+        )}
+      </div>
+    );
   };
 
   return (
@@ -64,14 +133,14 @@ const MyFullCalendar = () => {
         />
         <style>
           {`
-            .fc-myCustomButton-button {
-              background: url(${img_calendarPopUpBtn}) no-repeat center center;
-              background-size: contain;
-              border: none;
-              width: 33px; /* 적절한 너비로 설정 */
-              height: 33px; /* 적절한 높이로 설정 */
-            }
-          `}
+              .fc-myCustomButton-button {
+                background: url(${img_calendarPopUpBtn}) no-repeat center center;
+                background-size: contain;
+                border: none;
+                width: 33px; /* 적절한 너비로 설정 */
+                height: 33px; /* 적절한 높이로 설정 */
+              }
+            `}
         </style>
       </CalendarWrapper>
       <CalendarToggleButton
@@ -83,7 +152,10 @@ const MyFullCalendar = () => {
         alt="Calendar Toggle Button"
         onClick={toggleView}
       />
-      <MySchedule selectedDate={selectedDate}/>
+      <MySchedule
+        selectedDate={selectedDate}
+        updateScheduleDates={updateScheduleDates}
+      />
       <Mission />
       <DatePopUp
         isOpen={isModalOpen}

--- a/src/pages/MyFullCalendar.js
+++ b/src/pages/MyFullCalendar.js
@@ -125,9 +125,9 @@ const MyFullCalendar = () => {
           titleFormat={{ year: 'numeric', month: 'short' }}
           height={
             currentView === 'dayGridWeek'
-              ? 263
+              ? 228
               : currentView === 'dayGridMonth'
-                ? 600
+                ? 570
                 : 'auto'
           }
         />

--- a/src/styles/calendar/Calendar-styled.js
+++ b/src/styles/calendar/Calendar-styled.js
@@ -11,7 +11,6 @@ export const CalendarWrapper = styled.div`
     .fc .fc-scroller-harness.fc-scroller-harness-liquid {
       height: 414px;
       margin-top: 0px;
-      margin-bottom: 45px;
     }
     .fc .fc-scroller.fc-scroller-liquid-absolute {
       overflow-x: hidden;
@@ -39,7 +38,7 @@ export const CalendarWrapper = styled.div`
     .fc .fc-scroller-harness.fc-scroller-harness-liquid {
       height: 60px; //week view에서 점 안보이는 거 해결
       margin-top: 0px;
-      margin-bottom: 45px;
+      margin-bottom: 20px;
     }
     .fc .fc-scroller.fc-scroller-liquid-absolute {
       overflow-x: hidden;
@@ -52,14 +51,14 @@ export const CalendarWrapper = styled.div`
       height: 52px;
     }
     .fc-dayGridWeek-view {
-      height: 138px;
+      height: 122px;
     }
-    .fc-scrollgrid-section-body {
-      height: 87px;
+    .fc-scrollgrid.fc-scrollgrid-liquid {
+      //border: none;
+      height: 122px;
     }
   `}
 
-  
   //today
   .fc .fc-daygrid-day.fc-day-today {
     background-color: white;
@@ -80,7 +79,7 @@ export const CalendarWrapper = styled.div`
   }
   .fc .fc-toolbar-title {
     font-weight: 700;
-    width: 180px;
+    width: fit-content;
     margin: 0;
 
     text-align: center;
@@ -172,4 +171,5 @@ export const CalendarWrapper = styled.div`
 
 export const CalendarToggleButton = styled.img`
   margin-left: 281px;
+  cursor: pointer;
 `;

--- a/src/styles/calendar/Calendar-styled.js
+++ b/src/styles/calendar/Calendar-styled.js
@@ -100,11 +100,17 @@ export const CalendarWrapper = styled.div`
     border: none;
     padding: 0 13px 0 0;
   }
+  .fc .fc-prev-button:active {
+    background-color: white;
+  }
   .fc .fc-next-button {
     background-color: white;
     border: none;
     padding: 0 0 0 13px;
     margin-left: 0;
+  }
+  .fc .fc-next-button:active {
+    background-color: white;
   }
   //toolbar
 

--- a/src/styles/calendar/Calendar-styled.js
+++ b/src/styles/calendar/Calendar-styled.js
@@ -3,8 +3,6 @@ import styled from 'styled-components';
 export const CalendarWrapper = styled.div`
   width: 494px;
   margin: 0 auto;
-  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
-  background-color: white;
 
   // dayGridMonth일 때
   ${(props) =>
@@ -17,7 +15,7 @@ export const CalendarWrapper = styled.div`
     }
     .fc .fc-scroller.fc-scroller-liquid-absolute {
       overflow-x: hidden;
-      //overflow-y: hidden !important;
+      overflow-y: hidden !important;
     }
     .fc-daygrid-body-unbalanced {
       height: 414px;
@@ -39,7 +37,7 @@ export const CalendarWrapper = styled.div`
     props.view === 'dayGridWeek' &&
     `
     .fc .fc-scroller-harness.fc-scroller-harness-liquid {
-      height: 52px;
+      height: 60px; //week view에서 점 안보이는 거 해결
       margin-top: 0px;
       margin-bottom: 45px;
     }


### PR DESCRIPTION
**1. 캘린더 상세 스타일링**

<img width="381" alt="image" src="https://github.com/user-attachments/assets/3de7b9ea-ecf8-4b10-b424-95b9089043c8">

캘린더 내의 요소 간격 조절 + 캘린더 토글 버튼 위치 조절

**2. 일정 개수 반환 API 적용**

일정 개수 반환 API : 특정 날짜를 파라미터로 사용하여 그 날짜를 포함한 달의 모든 일정을 반환함 (날짜, 일정 개수)

```
const datesWithSchedules = response.data.reduce((acc, entry) => {
          acc[entry.date] = entry.count;
          return acc;
        }, {});
```

반환 받은 데이터를 reduce 메서드를 사용하여 배열을 객체로 변환
ex. 2024-07-27: 3

**3. 일정 개수를 바탕으로 캘린더 날짜 밑에 점으로 표시**

<img width="341" alt="image" src="https://github.com/user-attachments/assets/b48af2fc-3db6-466f-a99e-1eace675081b">

```dayCellContent 함수```

일정이 하나 있을 시 점 한 개 표시
일정이 두 개 이상 있을 시 최대 점 두 개 표시

**4. 일정 등록 + 삭제 시 점 추가 or 삭제**

```
  const updateScheduleDates = (date, countChange) => {
    setScheduleDates((prev) => {
      const newScheduleDates = { ...prev };
      newScheduleDates[date] = (newScheduleDates[date] || 0) + countChange;
      if (newScheduleDates[date] <= 0) delete newScheduleDates[date];
      return newScheduleDates;
    });
  };
```

일정 개수 업데이트 하는 updateScheduleDates 함수 생성

```updateScheduleDates(isoDate, -1);```
일정 삭제했을 시 일정 개수 감소 시켜 page 렌더링 되도록 함
```updateScheduleDates(date, 1);```
일정 추가했을 시 일정 개수를 증가 시켜 page 렌더링 되도록 함

**5. 이슈 사항**

<img width="200" alt="image" src="https://github.com/user-attachments/assets/4947a8c0-3fa4-49ff-8c62-929579b5d662">

full calendar api에서 제공하는 버튼인 next, prev 버튼을 클릭했을 때 border를 없애는 방법을 모르겠습니다...